### PR TITLE
Update deprecated use of #exists?

### DIFF
--- a/lib/grim/pdf.rb
+++ b/lib/grim/pdf.rb
@@ -15,7 +15,7 @@ module Grim
     #                             (default: "pdftotext").
     #
     def initialize(path, options = {})
-      raise Grim::PdfNotFound unless File.exists?(path)
+      raise Grim::PdfNotFound unless File.exist?(path)
       @path = path
       @pdftotext_path = options[:pdftotext_path] || 'pdftotext'
     end


### PR DESCRIPTION
File#exists? is removed in Ruby 3.2